### PR TITLE
feat: add SEO meta tags, OG cards, sitemap and JSON-LD schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,40 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Analytics Engineer & MCP Developer. 10+ years across GA4, GTM, BigQuery, Snowflake and Dataform. I build MCP servers that let teams query analytics data in plain English." />
+
+    <!-- Canonical -->
+    <link rel="canonical" href="https://damupi.com" />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="David Pino — Analytics & AI Engineer" />
+    <meta property="og:description" content="I build MCP servers, CLI tools, AI automations, and analytics systems." />
+    <meta property="og:url" content="https://damupi.com" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="https://damupi.com/avatar.jpeg" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="David Pino — Analytics & AI Engineer" />
+    <meta name="twitter:description" content="I build MCP servers, CLI tools, AI automations, and analytics systems." />
+    <meta name="twitter:image" content="https://damupi.com/avatar.jpeg" />
+
+    <!-- JSON-LD Person schema -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "David Pino",
+      "url": "https://damupi.com",
+      "jobTitle": "Analytics & AI Engineer",
+      "sameAs": [
+        "https://github.com/damupi",
+        "https://x.com/damupi/",
+        "https://t.me/damupi_contact_bot",
+        "https://njump.me/npub1hka7d6gsy2hetge3amg47png43r9t6m7k5w8s6yhhh9q33cd6j4q0nrvth"
+      ]
+    }
+    </script>
+
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://damupi.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://damupi.com</loc>
+    <lastmod>2026-06-21</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

- Add Open Graph and Twitter Card meta tags (`og:title`, `og:description`, `og:url`, `og:type`, `og:image`, `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`) to `index.html`
- Add `<link rel="canonical" href="https://damupi.com" />` to `index.html`
- Add JSON-LD `Person` schema in `index.html` with all social profile URLs sourced from the Contact component (GitHub, X/Twitter, Telegram, Nostr)
- Create `public/sitemap.xml` with weekly changefreq and priority 1.0
- Create `public/robots.txt` allowing all crawlers and referencing the sitemap

## Test plan

- [ ] Build passes: `npm run build` exits with no errors
- [ ] Validate OG tags with [https://opengraph.xyz](https://opengraph.xyz) after deploy
- [ ] Validate JSON-LD with [Google Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Confirm `https://damupi.com/sitemap.xml` is accessible after deploy
- [ ] Confirm `https://damupi.com/robots.txt` is accessible after deploy
- [ ] Submit sitemap to Google Search Console